### PR TITLE
docs(API): expose `ElementTemplates#get`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -6,7 +6,7 @@ The core element template functionality is exposed through the [`ElementTemplate
 
 ### `ElementTemplates#get(diagramElement): Template|null`
 
-Get the element template currently applied to a diagram element. Returns `null` if no template is applied or the applied template is not known to the modeler.
+Get the element template currently applied to a diagram element. Returns `null` if no template is applied or if the applied template is not known to the modeler.
 
 ```javascript
 const elementTemplates = bpmnJS.get('elementTemplates')
@@ -16,7 +16,7 @@ const template = elementTemplates.get('My_Task');
 
 ### `ElementTemplates#get(templateId, templateVersion?): Template|null`
 
-Get the element template with the given id and optional version. If no version is provided it defaults to latest. Returns `null` if no template is found matching the search criteria.
+Get the element template with the given id and optional version. If no version is provided it defaults to latest. Returns `null` if no template matches the search criteria.
 
 ```javascript
 const elementTemplates = bpmnJS.get('elementTemplates')

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,6 +4,42 @@ The core element template functionality is exposed through the [`ElementTemplate
 
 > If you [create your own element templates provider](https://github.com/bpmn-io/element-templates/blob/main/docs/CREATE_ELEMENT_TEMPLATE_PROVIDER.md) then you must at least implement the `ElementTemplates` interface and exposed it as the named `elementTemplates` service.
 
+### `ElementTemplates#get(diagramElement): Template|null`
+
+Get the element template currently applied to a diagram element. Returns `null` if no template is applied or the applied template is not known to the modeler.
+
+```javascript
+const elementTemplates = bpmnJS.get('elementTemplates')
+
+const template = elementTemplates.get('My_Task');
+```
+
+### `ElementTemplates#get(templateId, templateVersion?): Template|null`
+
+Get the element template with the given id and optional version. If no version is provided it defaults to latest. Returns `null` if no template is found matching the search criteria.
+
+```javascript
+const elementTemplates = bpmnJS.get('elementTemplates')
+
+const template = elementTemplates.get('MyFancyTemplate', 1);
+```
+
+### `ElementTemplates#createElement(template): DiagramElement`
+
+Create a new element from a template.
+
+### `ElementTemplates#applyTemplate(element, template): DiagramElement`
+
+Apply a template to an element (potentially replacing the element, applying property bindings, ...). Returns the element.
+
+### `ElementTemplates#getLatest(element|templateId): Template[]`
+
+Get element templates applicable to `element` or matching template with `templateId`.
+
+### `ElementTemplates#getLatest(): Template[]`
+
+Get list of element templates available.
+
 ### `ElementTemplatesLoader#setTemplates(templates)`
 
 Validates and sets element templates synchronously. Does not throw on template errors but instead emits them through an `elementTemplates.errors` event.
@@ -25,19 +61,3 @@ const templates = [
 // set templates
 loader.setTemplates(templates);
 ```
-
-### `ElementTemplates#createElement(template): DiagramElement`
-
-Create a new element from a template.
-
-### `ElementTemplates#applyTemplate(element, template): DiagramElement`
-
-Apply a template to an element (potentially replacing the element, applying property bindings, ...). Returns the element.
-
-### `ElementTemplates#getLatest(element|templateId): Template[]`
-
-Get element templates applicable to `element` or matching template with `templateId`.
-
-### `ElementTemplates#getLatest(): Template[]`
-
-Get list of element templates available.


### PR DESCRIPTION
Tell people about the fact that `ElementTemplates#get` is a thing.